### PR TITLE
セカンダリ設定

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,31 @@
           "type": "string",
           "default": "\"([^\"]+)\"",
           "description": "ファイルパスを抽出するための正規表現パターンを指定します。"
+        },
+        "go-path-jumper.SecondarySplitter": {
+          "type": "string",
+          "default": "/",
+          "description": "ファイルのベースパスのスプリッターを設定します。"
+        },
+        "go-path-jumper.SecondaryBasePath": {
+          "type": "string",
+          "default": "/",
+          "description": "ファイルのベースパスを指定します。"
+        },
+        "go-path-jumper.SecondaryFileExtension": {
+          "type": "string",
+          "default": ".csv",
+          "description": "ファイルの拡張子を指定します。"
+        },
+        "go-path-jumper.SecondaryRegexPattern": {
+          "type": "string",
+          "default": "\".*\"",
+          "description": "ファイルパスを検出するための正規表現パターンを指定します。"
+        },
+        "go-path-jumper.SecondaryRegexMatchPattern": {
+          "type": "string",
+          "default": "\"([^\"]+)\"",
+          "description": "ファイルパスを抽出するための正規表現パターンを指定します。"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,23 +2,59 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 export function activate(context: vscode.ExtensionContext) {
-	const disposable = vscode.languages.registerDefinitionProvider(
-        { scheme: 'file', language: 'go' },
+    const disposable = vscode.languages.registerDefinitionProvider(
+        [
+            { scheme: 'file', language: 'go' },
+            { scheme: 'file', language: 'svelte' },
+        ],
         {
             provideDefinition(document: vscode.TextDocument, position: vscode.Position) {
                 const config = vscode.workspace.getConfiguration('go-path-jumper');
-                const regexPattern = new RegExp(config.get('RegexPattern', ''));
-                const regexMatchPattern = new RegExp(config.get('RegexMatchPattern', ''));
-                const basePath = config.get('BasePath', '');
-				const fileExtension = config.get('FileExtension', '');
 
-                const range = document.getWordRangeAtPosition(position, regexPattern);
-                if (!range) {
+                const Settings = {
+                    "default": {
+                        regexPattern: new RegExp(config.get('RegexPattern', '')),
+                        regexMatchPattern: new RegExp(config.get('RegexMatchPattern', '')),
+                        basePath: config.get('BasePath', ''),
+                        fileExtension: config.get('FileExtension', ''),
+                        splitter: "/",
+                        notFoundPath: config.get('SecondaryNotFoundPath', ''),
+                    },
+                    "secondary": {
+                        regexPattern: new RegExp(config.get('SecondaryRegexPattern', '')),
+                        regexMatchPattern: new RegExp(config.get('SecondaryRegexMatchPattern', '')),
+                        basePath: config.get('SecondaryBasePath', ''),
+                        fileExtension: config.get('SecondaryFileExtension', ''),
+                        splitter: config.get('SecondarySplitter', ''),
+                        notFoundPath: config.get('SecondaryNotFoundPath', ''),
+                    }
+                }
+
+
+                const r1 = document.getWordRangeAtPosition(position, Settings.default.regexPattern);
+                const r2 = document.getWordRangeAtPosition(position, Settings.secondary.regexPattern);
+
+                var pattern: "default" | "secondary" = "default";
+
+                let range: vscode.Range;
+                if (r1) {
+                    pattern = "default";
+                    range = r1;
+                } else if (r2) {
+                    pattern = "secondary";
+                    range = r2;
+                } else {
                     return null;
                 }
 
-                const matchResult = document.getText(range).match(regexMatchPattern);
-                const filePath = matchResult ? matchResult[1] : null;
+                const applySettings = Settings[pattern];
+
+                const matchResult = document.getText(range).match(applySettings.regexMatchPattern);
+                let filePath = matchResult ? matchResult[1] : null;
+
+                if (filePath) {
+                    filePath = filePath.replaceAll(applySettings.splitter, "/");
+                }
 
                 const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
                 if (!workspaceFolder) {
@@ -27,15 +63,15 @@ export function activate(context: vscode.ExtensionContext) {
                 }
                 const rootPath = workspaceFolder?.uri.fsPath;
 
-                const fullPath = path.join(rootPath, basePath, filePath + fileExtension);
-                const fileUri = vscode.Uri.file(fullPath);
+                let fullPath = path.join(rootPath, applySettings.basePath, filePath + applySettings.fileExtension);
+                let fileUri = vscode.Uri.file(fullPath);
 
                 return new vscode.Location(fileUri, new vscode.Position(0, 0));
             }
         }
     )
 
-	context.subscriptions.push(disposable);
+    context.subscriptions.push(disposable);
 }
 
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
## 概要
セカンダリ設定を任意で設定できるように修正

## 変更内容
- 拡張機能の設定画面から任意のセカンダリ設定を登録して、遷移できるように修正
-

## テスト結果
- [x] 既存のgoファイルからSqlに遷移できることを確認
- [x] 新たに、svelteのファイルからgoファイルに遷移できることを確認

## 関連資料